### PR TITLE
add roslaunch to build dependencies, since it is required in cmakelist

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
   <url>http://ros.org/wiki/urdf_tutorial</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-
+  <build_depend>roslaunch</build_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>diff_drive_controller</run_depend>
   <run_depend>gazebo_ros</run_depend>


### PR DESCRIPTION
fix #16