### PR TITLE
Check CATKIN_ENABLE_TESTING flag before adding tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(urdf_tutorial)
 find_package(catkin REQUIRED roslaunch)
 catkin_package()
 
-roslaunch_add_file_check(launch)
+if(CATKIN_ENABLE_TESTING)
+  roslaunch_add_file_check(launch)
+endif()
 
 install(DIRECTORY config images meshes launch rviz urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
I came across this small detail almost by pure chance. The catkin build failed in a strange way, complaining about undefined macros that eventually led me to the fact that CMakeLists.txt was not checking whether it should add the test or not.