### PR TITLE
Remove extraneous <origin> tags from 05-visual and 06-flexible example URDFs

### DIFF
--- a/urdf/05-visual.urdf
+++ b/urdf/05-visual.urdf
@@ -58,7 +58,6 @@
         <cylinder length="0.1" radius="0.035"/>
       </geometry>
       <material name="black"/>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
     </visual>
   </link>
   <joint name="right_front_wheel_joint" type="fixed">

--- a/urdf/06-flexible.urdf
+++ b/urdf/06-flexible.urdf
@@ -58,7 +58,6 @@
         <cylinder length="0.1" radius="0.035"/>
       </geometry>
       <material name="black"/>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
     </visual>
   </link>
   <joint name="right_front_wheel_joint" type="continuous">


### PR DESCRIPTION
These visual nodes have two `<origin>` tags, which can make them show up incorrectly depending on the URDF parser that was used:
![image](https://user-images.githubusercontent.com/14237/115084218-42f35300-9ea4-11eb-9154-d386589a4a1b.png)
