### PR TITLE
Fix a typo in launch that prevents it from working.

### DIFF
--- a/launch/display.launch.py
+++ b/launch/display.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
     ld.add_action(rviz_arg)
 
     # This parameter has changed its meaning slightly from previous versions
-    ld.add_action(DeclareLaunchArgument(name='model', default_value=str(default_model_path),
+    ld.add_action(DeclareLaunchArgument(name='model', default_value=default_model_path,
                                         description='Path to robot urdf file relative to urdf_tutorial package'))
 
     ld.add_action(IncludeLaunchDescription(


### PR DESCRIPTION
In particular, the default value for the model needs to be a substitution, not a string.  Otherwise trying to launch fails with a xacro failure.

Fixes #68 