### PR TITLE
Add forgotten package path

### DIFF
--- a/launch/display.launch.py
+++ b/launch/display.launch.py
@@ -8,7 +8,7 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     urdf_tutorial_path = FindPackageShare('urdf_tutorial')
-    default_model_path = PathJoinSubstitution(['urdf', '01-myfirst.urdf'])
+    default_model_path = PathJoinSubstitution([urdf_tutorial_path, 'urdf', '01-myfirst.urdf'])
     default_rviz_config_path = PathJoinSubstitution([urdf_tutorial_path, 'rviz', 'urdf.rviz'])
 
     # These parameters are maintained for backwards compatibility


### PR DESCRIPTION
As in ROS 2 docs contain example here: https://docs.ros.org/en/jazzy/Tutorials/Intermediate/Launch/Using-Substitutions.html#parent-launch-file, it's shown off that every called substitution needs to have FindPackageShare(). Here, that is not the case. Even if code is working, it is probably required to add the FindPackageShare().

Sorry if I am wrong, I am newcomer to ROS 2.