### PR TITLE
Fix display.launch.py default model path handling

### DIFF
--- a/launch/display.launch.py
+++ b/launch/display.launch.py
@@ -8,7 +8,7 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     urdf_tutorial_path = FindPackageShare('urdf_tutorial')
-    default_model_path = PathJoinSubstitution(['urdf', '01-myfirst.urdf'])
+    default_model_path = '01-myfirst.urdf'
     default_rviz_config_path = PathJoinSubstitution([urdf_tutorial_path, 'rviz', 'urdf.rviz'])
 
     # These parameters are maintained for backwards compatibility
@@ -27,7 +27,7 @@ def generate_launch_description():
         PathJoinSubstitution([FindPackageShare('urdf_launch'), 'launch', 'display.launch.py']),
         launch_arguments={
             'urdf_package': 'urdf_tutorial',
-            'urdf_package_path': LaunchConfiguration('model'),
+            'urdf_package_path': PathJoinSubstitution(['urdf', LaunchConfiguration('model')]),
             'rviz_config': LaunchConfiguration('rvizconfig'),
             'jsp_gui': LaunchConfiguration('gui')}.items()
     ))


### PR DESCRIPTION
While running the urdf_tutorial on a newer setup (ROS 2 Kilted on Ubuntu 24.04),
launching the tutorial failed unless the model path was manually prefixed with
`urdf/`.

The issue was caused by the default `model` launch argument being constructed
using a PathJoinSubstitution and then stringified. On newer ROS 2 / Python
versions, LaunchArgument defaults are treated strictly as strings, which led to
invalid URDF paths being passed to xacro.

This change:
- Uses a plain string as the default value for the `model` argument
- Prepends the `urdf/` directory at the tutorial level when invoking urdf_launch

This keeps urdf_launch generic while fixing the tutorial’s default behavior and
avoids requiring users to manually adjust paths.

Tested on ROS 2 Kilted (Ubuntu 24.04).
